### PR TITLE
Added readiness probe

### DIFF
--- a/pgpool-deploy.yaml
+++ b/pgpool-deploy.yaml
@@ -50,6 +50,11 @@ spec:
           mountPath: /config
         #- name: pgpool-tls
         #  mountPath: /config/tls
+        readinessProbe:
+          exec:
+            command: ["sh", "-c", "PGPASSWORD=$POSTGRES_PASSWORD psql -w -U $POSTGRES_USERNAME -c 'SELECT 1' -h localhost"]
+          timeoutSeconds: 2
+          periodSeconds: 5
       volumes:
       - name: pgpool-config
         configMap:


### PR DESCRIPTION
Added a readiness probe to the deployment.
This will help Kubernetes control planes to properly adjust the service endpoints depending on whether a PgPool-II pod is ready to accept a request or not.