### PR TITLE
Bumped base image to alpine 3.17 and added patch as an install target

### DIFF
--- a/pgpool.docker/Dockerfile.pgpool
+++ b/pgpool.docker/Dockerfile.pgpool
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.17
 
 ARG PGPOOL_VER
 
@@ -28,6 +28,7 @@ RUN set -eux \
         libbsd-doc \
         linux-headers \
         make \
+        patch \
         openssl-dev \
     \
     && apk add --no-cache \


### PR DESCRIPTION
On alpine 3.11, there are several known vulnerabilities. [reference](https://snyk.io/test/docker/alpine%3A3.11.9)
To fix these, this PR bumps the base image to alpine 3.17.